### PR TITLE
[#34] Feat: 바텀시트 구현

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,19 @@
  * @format
  */
 
-import {AppRegistry} from 'react-native';
-import App from './App';
-import {name as appName} from './app.json';
+import React from "react";
+import { AppRegistry } from "react-native";
+import "react-native-gesture-handler";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import App from "./App";
+import { name as appName } from "./app.json";
 
-AppRegistry.registerComponent(appName, () => App);
+function Main() {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <App />
+    </GestureHandlerRootView>
+  );
+}
+
+AppRegistry.registerComponent(appName, () => Main);

--- a/ios/BaamFrontend.xcodeproj/project.pbxproj
+++ b/ios/BaamFrontend.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		00E356EE1AD99517003FC87E /* BaamFrontendTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BaamFrontendTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* BaamFrontendTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BaamFrontendTests.m; sourceTree = "<group>"; };
-		12B69C6BDB7E4056B47FDD20 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Thin.otf"; path = "../src/assets/fonts/Pretendard-Thin.otf"; sourceTree = "<group>"; };
+		12B69C6BDB7E4056B47FDD20 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Thin.otf"; path = "../src/assets/fonts/Pretendard-Thin.otf"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* BaamFrontend.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaamFrontend.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = BaamFrontend/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = BaamFrontend/AppDelegate.mm; sourceTree = "<group>"; };
@@ -52,24 +52,24 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = BaamFrontend/main.m; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = BaamFrontend/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		19F6CBCC0A4E27FBF8BF4A61 /* libPods-BaamFrontend-BaamFrontendTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BaamFrontend-BaamFrontendTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		201C6419000C4233B1455C46 /* Pretendard-Black.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Black.otf"; path = "../src/assets/fonts/Pretendard-Black.otf"; sourceTree = "<group>"; };
+		201C6419000C4233B1455C46 /* Pretendard-Black.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Black.otf"; path = "../src/assets/fonts/Pretendard-Black.otf"; sourceTree = "<group>"; };
 		3B4392A12AC88292D35C810B /* Pods-BaamFrontend.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaamFrontend.debug.xcconfig"; path = "Target Support Files/Pods-BaamFrontend/Pods-BaamFrontend.debug.xcconfig"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-BaamFrontend.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaamFrontend.release.xcconfig"; path = "Target Support Files/Pods-BaamFrontend/Pods-BaamFrontend.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-BaamFrontend-BaamFrontendTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaamFrontend-BaamFrontendTests.debug.xcconfig"; path = "Target Support Files/Pods-BaamFrontend-BaamFrontendTests/Pods-BaamFrontend-BaamFrontendTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-BaamFrontend.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BaamFrontend.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		6A7118EA85411188953D33D1 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = BaamFrontend/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		6BCC3081A1264BB18445F1F0 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Regular.otf"; path = "../src/assets/fonts/Pretendard-Regular.otf"; sourceTree = "<group>"; };
+		6A7118EA85411188953D33D1 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = BaamFrontend/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		6BCC3081A1264BB18445F1F0 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Regular.otf"; path = "../src/assets/fonts/Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = BaamFrontend/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		848E00E77082473C95085183 /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-ExtraLight.otf"; path = "../src/assets/fonts/Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
+		848E00E77082473C95085183 /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-ExtraLight.otf"; path = "../src/assets/fonts/Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-BaamFrontend-BaamFrontendTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BaamFrontend-BaamFrontendTests.release.xcconfig"; path = "Target Support Files/Pods-BaamFrontend-BaamFrontendTests/Pods-BaamFrontend-BaamFrontendTests.release.xcconfig"; sourceTree = "<group>"; };
-		9CC7EF0E659D4AFEAD76C396 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-SemiBold.otf"; path = "../src/assets/fonts/Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
-		9F53AC78076D4F27A3CDF615 /* Pretendard-ExtraBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-ExtraBold.otf"; path = "../src/assets/fonts/Pretendard-ExtraBold.otf"; sourceTree = "<group>"; };
-		ADF1C71D7F844CF3ABA3E00F /* EsaManruLight.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = EsaManruLight.otf; path = ../src/assets/fonts/EsaManruLight.otf; sourceTree = "<group>"; };
-		AE13F0A3B4A94D1EA42B1A23 /* Pretendard-Light.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Light.otf"; path = "../src/assets/fonts/Pretendard-Light.otf"; sourceTree = "<group>"; };
-		C0878E26DC3545949C6115F6 /* EsaManruBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = EsaManruBold.otf; path = ../src/assets/fonts/EsaManruBold.otf; sourceTree = "<group>"; };
-		C2A21A843ADD4F948BE9C9DE /* Pretendard-Bold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Bold.otf"; path = "../src/assets/fonts/Pretendard-Bold.otf"; sourceTree = "<group>"; };
-		CB0EF2B80CAF48E8A263115D /* EsaManruMedium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = EsaManruMedium.otf; path = ../src/assets/fonts/EsaManruMedium.otf; sourceTree = "<group>"; };
-		D2CAC4151764489CAC1F7C76 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Medium.otf"; path = "../src/assets/fonts/Pretendard-Medium.otf"; sourceTree = "<group>"; };
+		9CC7EF0E659D4AFEAD76C396 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-SemiBold.otf"; path = "../src/assets/fonts/Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
+		9F53AC78076D4F27A3CDF615 /* Pretendard-ExtraBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-ExtraBold.otf"; path = "../src/assets/fonts/Pretendard-ExtraBold.otf"; sourceTree = "<group>"; };
+		ADF1C71D7F844CF3ABA3E00F /* EsaManruLight.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EsaManruLight.otf; path = ../src/assets/fonts/EsaManruLight.otf; sourceTree = "<group>"; };
+		AE13F0A3B4A94D1EA42B1A23 /* Pretendard-Light.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Light.otf"; path = "../src/assets/fonts/Pretendard-Light.otf"; sourceTree = "<group>"; };
+		C0878E26DC3545949C6115F6 /* EsaManruBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EsaManruBold.otf; path = ../src/assets/fonts/EsaManruBold.otf; sourceTree = "<group>"; };
+		C2A21A843ADD4F948BE9C9DE /* Pretendard-Bold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Bold.otf"; path = "../src/assets/fonts/Pretendard-Bold.otf"; sourceTree = "<group>"; };
+		CB0EF2B80CAF48E8A263115D /* EsaManruMedium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EsaManruMedium.otf; path = ../src/assets/fonts/EsaManruMedium.otf; sourceTree = "<group>"; };
+		D2CAC4151764489CAC1F7C76 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Medium.otf"; path = "../src/assets/fonts/Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -184,7 +184,6 @@
 				12B69C6BDB7E4056B47FDD20 /* Pretendard-Thin.otf */,
 			);
 			name = Resources;
-			path = "";
 			sourceTree = "<group>";
 		};
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
@@ -529,6 +528,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DUNJU8DK39;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = BaamFrontend/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -556,6 +556,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DUNJU8DK39;
 				INFOPLIST_FILE = BaamFrontend/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -647,10 +648,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -722,10 +720,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1191,8 +1191,29 @@ PODS:
     - React-utils (= 0.74.2)
   - RNCAsyncStorage (1.23.1):
     - React-Core
-  - RNDateTimePicker (8.1.1):
+  - RNDateTimePicker (8.2.0):
     - React-Core
+  - RNGestureHandler (2.17.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNReanimated (3.14.0):
     - DoubleConversion
     - glog
@@ -1323,6 +1344,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
+  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -1451,6 +1473,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNDateTimePicker:
     :path: "../node_modules/@react-native-community/datetimepicker"
+  RNGestureHandler:
+    :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -1520,7 +1544,8 @@ SPEC CHECKSUMS:
   React-utils: 4476b7fcbbd95cfd002f3e778616155241d86e31
   ReactCommon: ecad995f26e0d1e24061f60f4e5d74782f003f12
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
-  RNDateTimePicker: 430174392d275f0ffefb627d04f0f8677f667fed
+  RNDateTimePicker: 40ffda97d071a98a10fdca4fa97e3977102ccd14
+  RNGestureHandler: 8dbcccada4a7e702e7dec9338c251b1cf393c960
   RNReanimated: f4ff116e33e0afc3d127f70efe928847c7c66355
   RNScreens: 5aeecbb09aa7285379b6e9f3c8a3c859bb16401c
   RNSVG: cb24fb322de8c1ebf59904e7aca0447bb8dbed5a

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.11.4",
+        "@gorhom/bottom-sheet": "^4.6.4",
         "@react-native-async-storage/async-storage": "^1.23.1",
         "@react-native-community/datetimepicker": "^8.1.1",
         "@react-navigation/bottom-tabs": "^6.6.0",
@@ -22,6 +23,7 @@
         "react-native": "0.74.2",
         "react-native-calendars": "^1.1306.0",
         "react-native-date-picker": "^5.0.4",
+        "react-native-gesture-handler": "^2.17.1",
         "react-native-image-picker": "^7.1.2",
         "react-native-modal-datetime-picker": "^17.1.0",
         "react-native-reanimated": "^3.14.0",
@@ -2071,6 +2073,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
@@ -2354,6 +2367,43 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.6.4.tgz",
+      "integrity": "sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=1.10.1",
+        "react-native-reanimated": ">=2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -5095,6 +5145,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.45.tgz",
+      "integrity": "sha512-qkcUlZmX6c4J8q45taBKTL3p+LbITgyx7qhlPYOdOHZB7B31K0mXbP5YA7i7SgDeEGuI9MnumiKPEMrxg8j3KQ=="
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -5162,7 +5217,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.73.0.tgz",
       "integrity": "sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==",
       "deprecated": "This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "react-native": "*"
       }
@@ -13270,6 +13325,21 @@
       "peerDependencies": {
         "react": ">= 17.0.1",
         "react-native": ">= 0.64.3"
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.17.1.tgz",
+      "integrity": "sha512-pWfniN6NuVKUq40KACuD3NCMe+bWNQCpD3cmxL6aLSCTwPKYmf7l4Lp0/E/almpjvxhybJZtFLU0w4tmxnIKaA==",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-image-picker": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/native": "^11.11.0",
     "@emotion/react": "^11.11.4",
+    "@gorhom/bottom-sheet": "^4.6.4",
     "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-native-community/datetimepicker": "^8.1.1",
     "@react-navigation/bottom-tabs": "^6.6.0",
@@ -24,6 +25,7 @@
     "react-native": "0.74.2",
     "react-native-calendars": "^1.1306.0",
     "react-native-date-picker": "^5.0.4",
+    "react-native-gesture-handler": "^2.17.1",
     "react-native-image-picker": "^7.1.2",
     "react-native-modal-datetime-picker": "^17.1.0",
     "react-native-reanimated": "^3.14.0",

--- a/src/hooks/useBottomSheet.tsx
+++ b/src/hooks/useBottomSheet.tsx
@@ -1,0 +1,93 @@
+import styled from "@emotion/native";
+import BottomSheet, { BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Theme } from "../styles/theme";
+
+interface BottomSheetComponentProps {
+  children: React.ReactNode;
+  snapPoints?: (string | number)[];
+}
+
+const useBottomSheet = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const sheetRef = useRef<BottomSheet>(null);
+
+  const openSheet = useCallback(() => setIsVisible(true), []);
+  const closeSheet = useCallback(() => setIsVisible(false), []);
+
+  const handleSheetChanges = useCallback((index: number) => {
+    if (index === -1) setIsVisible(false);
+  }, []);
+
+  function BottomSheetComponent({ children, snapPoints = ["25%", "50%", "90%"] }: BottomSheetComponentProps) {
+    useEffect(() => {
+      if (isVisible) sheetRef.current?.expand();
+    }, [isVisible]);
+
+    return (
+      <>
+        {isVisible && <Overlay onTouchEnd={closeSheet} />}
+        <BottomSheet
+          ref={sheetRef}
+          snapPoints={snapPoints}
+          index={isVisible ? 1 : -1}
+          enablePanDownToClose={true}
+          onChange={handleSheetChanges}
+          handleComponent={() => (
+            <CustomHandle>
+              <Knob />
+            </CustomHandle>
+          )}
+          backgroundStyle={bottomSheetBackground}
+        >
+          <BottomSheetScrollView contentContainerStyle={contentContainer} showsVerticalScrollIndicator={false}>
+            {children}
+          </BottomSheetScrollView>
+        </BottomSheet>
+      </>
+    );
+  }
+
+  return {
+    isVisible,
+    openSheet,
+    closeSheet,
+    BottomSheetComponent
+  };
+};
+
+const Overlay = styled.View({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: "rgba(0, 0, 0, 0.5)"
+});
+
+const CustomHandle = styled.View({
+  width: "100%",
+  paddingTop: 16,
+  paddingBottom: 20,
+  justifyContent: "center",
+  alignItems: "center"
+});
+
+const Knob = styled.View({
+  width: 80,
+  height: 4,
+  backgroundColor: Theme.colors.Black,
+  borderRadius: 4
+});
+
+const bottomSheetBackground = {
+  borderTopLeftRadius: 24,
+  borderTopRightRadius: 24
+};
+
+const contentContainer = {
+  paddingHorizontal: 16,
+  paddingBottom: 20
+};
+
+export default useBottomSheet;


### PR DESCRIPTION
#### 작업 내용

- 바텀시트 바깥쪽을 클릭하거나 바텀시트를 아래로 내리면 닫히고, useBottomSheet 훅의 closeSheet 함수를 이용해서 닫을 수 있도록 구현했습니다.

- gorhom/bottom-sheet와 react-native-gesture-handler를 설치해서 이번에도 npm i 한번씩 부탁드리겠습니다 🥺


#### 스크린샷

![Jul-30-2024 11-31-06](https://github.com/user-attachments/assets/9bfdf55d-3533-47a2-b918-190a10a6d4ca)
![Jul-30-2024 11-31-14](https://github.com/user-attachments/assets/fa74b755-b7f2-45b8-bba6-0237ef103227)


#### 사용 예시

```tsx
import React from "react";
import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
import useBottomSheet from "../hooks/useBottomSheet";

const TestScreen = () => {
  const { openSheet, closeSheet, BottomSheetComponent } = useBottomSheet();

  return (
    <View style={styles.container}>
      <TouchableOpacity onPress={openSheet} style={styles.button}>
        <Text>Show Modal</Text>
      </TouchableOpacity>
      <BottomSheetComponent>
        <Text style={styles.modalText}>모달입니다</Text>
        <View style={{ backgroundColor: "lightgray", gap: 30 }}>
          {Array.from({ length: 30 }).map((_, index) => (
            <Text key={index}>모달 내용 {index + 1}</Text>
          ))}
        </View>
      </BottomSheetComponent>
    </View>
  );
};

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: "center",
    alignItems: "center",
    backgroundColor: "#f0f0f0"
  },
  button: {
    padding: 10,
    backgroundColor: "#007BFF",
    borderRadius: 5,
    marginBottom: 20
  },

  modalText: {
    fontSize: 18,
    marginBottom: 10
  }
});

export default TestScreen;

```



close #34