### PR TITLE
홈 화면 (DateCarousel, 친한 친구, 급식)

### DIFF
--- a/src/apis/favorite-friends/favorite-friends.apis.ts
+++ b/src/apis/favorite-friends/favorite-friends.apis.ts
@@ -1,0 +1,14 @@
+import { customAxios } from "../instance";
+import { FavoriteFriendResponse } from "./favorite-friends.type";
+
+export const getFavoriteFriends = async ({
+  count,
+  page
+}: {
+  count: number;
+  page: number;
+}): Promise<FavoriteFriendResponse> => {
+  const response = await customAxios.get<FavoriteFriendResponse>(`friends/favorites?count=${count}&page=${page}`);
+
+  return response.data;
+};

--- a/src/apis/favorite-friends/favorite-friends.type.ts
+++ b/src/apis/favorite-friends/favorite-friends.type.ts
@@ -1,0 +1,11 @@
+export interface FavoriteFriend {
+  userId: number;
+  fullName: string;
+  profileImage: string;
+  activeClassNow: string;
+}
+
+export interface FavoriteFriendResponse {
+  total: number;
+  list: FavoriteFriend[];
+}

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -7,7 +7,8 @@ const customAxios: AxiosInstance = axios.create({
   headers: {
     accept: "application/json",
     "Content-Type": "application/json"
-  }
+  },
+  timeout: 10000,
 });
 
 // AsyncStorage.getItem 함수: 비동기 > 요청 인터셉터로 토큰을 동적 추가

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -8,7 +8,6 @@ const customAxios: AxiosInstance = axios.create({
     accept: "application/json",
     "Content-Type": "application/json"
   },
-  timeout: 10000,
 });
 
 // AsyncStorage.getItem 함수: 비동기 > 요청 인터셉터로 토큰을 동적 추가

--- a/src/apis/meal/meal.ts
+++ b/src/apis/meal/meal.ts
@@ -1,9 +1,11 @@
 import { MealResponse } from "@/types/meal";
 import axios from "axios";
+import { SERVER_HOST } from "@env";
 
 export const fetchMealData = async (schoolId: number, date: string): Promise<MealResponse> => {
-  // token 없이 호출하는 API
-  const response = await axios.get(`https://b-site.site/school-dataset/meal?schoolId=${schoolId}&date=${date}`);
+  // 급식 API 는 토큰 필요 없음
+  // 예외처리도 schoolId Not Found 만 있음
+  const response = await axios.get(`${SERVER_HOST}/school-dataset/meal?schoolId=${schoolId}&date=${date}`);
 
   return response.data;
 };

--- a/src/apis/meal/meal.ts
+++ b/src/apis/meal/meal.ts
@@ -1,0 +1,9 @@
+import { MealResponse } from "@/types/meal";
+import axios from "axios";
+
+export const fetchMealData = async (schoolId: number, date: string): Promise<MealResponse> => {
+  const response = await axios.get(`https://b-site.site/school-dataset/meal?schoolId=${schoolId}&date=${date}`);
+  console.log(response);
+
+  return response.data;
+};

--- a/src/apis/meal/meal.ts
+++ b/src/apis/meal/meal.ts
@@ -2,8 +2,8 @@ import { MealResponse } from "@/types/meal";
 import axios from "axios";
 
 export const fetchMealData = async (schoolId: number, date: string): Promise<MealResponse> => {
+  // token 없이 호출하는 API
   const response = await axios.get(`https://b-site.site/school-dataset/meal?schoolId=${schoolId}&date=${date}`);
-  console.log(response);
 
   return response.data;
 };

--- a/src/components/home/DateCarousel.tsx
+++ b/src/components/home/DateCarousel.tsx
@@ -1,18 +1,20 @@
 import React, { useState, useRef } from "react";
-import { View, Text, FlatList, StyleSheet, Image, TouchableOpacity, Pressable } from "react-native";
+import { FlatList, Pressable } from "react-native";
 import moment, { Moment } from "moment";
-import DateCarouselItem from "./DateCarouselItem";
 import styled from "@emotion/native";
-import { Theme } from "../../styles/theme";
 import "moment/locale/ko";
-
-moment.locale("ko");
+import { DropDownDown, IconBell } from "@/assets/assets";
 
 type DateItem = Moment;
 
+interface DateCarouselProps {
+  selectedDate: Moment;
+  onDateChange: (date: Moment) => void;
+}
+
 const generateDatesForMonth = (currentMonth: Moment): DateItem[] => {
-  const startOfMonth = currentMonth.clone().startOf("month"); // 해당 월의 첫날
-  const endOfMonth = currentMonth.clone().endOf("month"); // 해당 월의 마지막 날
+  const startOfMonth = currentMonth.clone().startOf("month");
+  const endOfMonth = currentMonth.clone().endOf("month");
   const datesArray: DateItem[] = [];
 
   let currentDate = startOfMonth;
@@ -24,7 +26,7 @@ const generateDatesForMonth = (currentMonth: Moment): DateItem[] => {
   return datesArray;
 };
 
-const DateCarousel: React.FC = () => {
+const DateCarousel: React.FC<DateCarouselProps> = ({ selectedDate, onDateChange }) => {
   const [currentMonth, setCurrentMonth] = useState<Moment>(moment());
   const [dates, setDates] = useState<DateItem[]>(generateDatesForMonth(currentMonth));
   const flatListRef = useRef<FlatList<DateItem>>(null);
@@ -35,10 +37,10 @@ const DateCarousel: React.FC = () => {
     const newMonth = currentMonth.clone().add(direction === "next" ? 1 : -1, "month");
     setCurrentMonth(newMonth);
     setDates(generateDatesForMonth(newMonth));
-    flatListRef.current?.scrollToOffset({ offset: 0, animated: false }); // 월 변경 시 리스트를 처음으로 스크롤
+    flatListRef.current?.scrollToOffset({ offset: 0, animated: false });
   };
 
-  const handleItemPress = (index: number) => {
+  const handleDatePress = (index: number, date: Moment) => {
     if (flatListRef.current) {
       flatListRef.current.scrollToIndex({
         index,
@@ -47,39 +49,63 @@ const DateCarousel: React.FC = () => {
         viewPosition: 0.25
       });
     }
+    onDateChange(date);
   };
 
   const renderItem = ({ item, index }: { item: DateItem; index: number }) => {
-    return <DateCarouselItem item={item} onPress={() => handleItemPress(index + 1)} />;
+    const isSelected = item.isSame(selectedDate, "day");
+    const isToday = item.isSame(moment(), "day");
+
+    return (
+      <DateItemContainer onPress={() => handleDatePress(index, item)} isSelected={isSelected}>
+        <IndicatorContainer>
+          {isToday ? (
+            <>
+              <GrayDot />
+              <GrayDot />
+              <GrayDot />
+            </>
+          ) : (
+            <GrayDot />
+          )}
+        </IndicatorContainer>
+        <DateNumber isSelected={isSelected}>{item.format("D")}</DateNumber>
+        {/* 요일은 영어로 표시(Mon..) 해야해서 여기서만 en 사용 */}
+        <DayText isSelected={isSelected}>{item.clone().locale("en").format("ddd")}</DayText>
+        {isSelected && <SelectedIndicator />}
+      </DateItemContainer>
+    );
   };
 
   return (
     <Container>
-      <MonthToolbar>
-        <Pressable onPress={() => handleMonthChange("prev")}>
-          <CustomImage source={require("../../assets/images/btn_left.png")} />
+      <TopBar>
+        <MonthContainer>
+          <MonthText>{currentMonth.format("M월")}</MonthText>
+          <Pressable>
+            <CalendarIconImage source={DropDownDown} style={{ transform: [{ scaleY: -1 }] }} />
+          </Pressable>
+        </MonthContainer>
+        <Pressable>
+          <NotificationIconImage source={IconBell} />
         </Pressable>
-        <MonthToolBarTitle>{currentMonth.format("MMMM")}</MonthToolBarTitle>
-        <Pressable onPress={() => handleMonthChange("prev")}>
-          <CustomImage source={require("../../assets/images/btn_left.png")} style={{ transform: [{ scaleX: -1 }] }} />
-        </Pressable>
-      </MonthToolbar>
+      </TopBar>
 
       <FlatList
         ref={flatListRef}
         data={dates}
         renderItem={renderItem}
-        keyExtractor={(item, index) => `${item.format("YYYY-MM-DD")}-${index}`}
+        keyExtractor={(item) => item.format("YYYY-MM-DD")}
         horizontal
         initialScrollIndex={todayIndex}
         showsHorizontalScrollIndicator={false}
-        contentContainerStyle={{ paddingHorizontal: 80 * 2 }}
+        contentContainerStyle={{ paddingHorizontal: 16 }}
         snapToAlignment="center"
-        snapToInterval={80}
+        snapToInterval={60}
         decelerationRate="fast"
         getItemLayout={(data, index) => ({
-          length: 80,
-          offset: 80 * index,
+          length: 60,
+          offset: 60 * index,
           index
         })}
         style={{ flexGrow: 0 }}
@@ -88,27 +114,107 @@ const DateCarousel: React.FC = () => {
   );
 };
 
-const Container = styled(View)`
-  flex-shrink: 1;
-  gap: 20px;
+const Container = styled.View`
+  width: 360px;
+  height: 144px;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 12px;
 `;
 
-const MonthToolbar = styled(View)`
-  padding: 0 16px;
-  height: 30px;
-  width: 100%;
+const TopBar = styled.View`
+  width: 360px;
+  height: 48px;
+  padding: 10px 16px;
+  background: white;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
 `;
 
-const MonthToolBarTitle = styled(Text)`
-  font-style: ${Theme.typo.Heading_01};
+const MonthContainer = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
 `;
 
-const CustomImage = styled(Image)`
-  width: 32px;
-  height: 32px;
+const MonthText = styled.Text`
+  color: black;
+  font-size: 24px;
+  font-family: "Esamanru OTF";
+  font-weight: 500;
+  line-height: 28px;
+`;
+
+const CalendarIconImage = styled.Image`
+  width: 24px;
+  height: 24px;
+`;
+
+const NotificationIconImage = styled.Image`
+  width: 24px;
+  height: 24px;
+`;
+
+const DateItemContainer = styled.Pressable<{ isSelected: boolean }>`
+  width: 68px;
+  height: 80px;
+  padding-top: 8px;
+  padding-bottom: 14px;
+  background: white;
+  border-radius: 12px;
+  border: 2px solid ${(props) => (props.isSelected ? "#434343" : "#E9E9E9")};
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  margin-right: 16px;
+  position: relative;
+`;
+
+const IndicatorContainer = styled.View`
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  position: absolute;
+  top: 4px;
+`;
+
+const GrayDot = styled.View`
+  width: 8px;
+  height: 8px;
+  background: rgba(217, 217, 217, 1);
+  border-radius: 4px;
+`;
+
+const DateNumber = styled.Text<{ isSelected: boolean }>`
+  color: ${(props) => (props.isSelected ? "#434343" : "black")};
+  font-size: 17px; // 원래 20px (잘려서 17px로 수정)
+  font-family: "Pretendard";
+  font-weight: 500;
+  line-height: 16px;
+  letter-spacing: 0.5px;
+  margin-top: 12px;
+`;
+
+const DayText = styled.Text<{ isSelected: boolean }>`
+  color: ${(props) => (props.isSelected ? "#434343" : "#7B7B7B")};
+  font-size: 14px;
+  font-family: "Pretendard";
+  font-weight: 500;
+  line-height: 16px;
+  letter-spacing: 0.5px;
+  margin-top: 4px;
+`;
+
+const SelectedIndicator = styled.View`
+  width: 40px;
+  height: 4px;
+  background: #434343;
+  border-radius: 2px;
+  position: absolute;
+  bottom: 4px;
 `;
 
 export default DateCarousel;

--- a/src/components/home/DateCarousel.tsx
+++ b/src/components/home/DateCarousel.tsx
@@ -158,8 +158,8 @@ const NotificationIconImage = styled.Image`
 `;
 
 const DateItemContainer = styled.Pressable<{ isSelected: boolean }>`
-  width: 68px;
-  height: 80px;
+  width: ${(props) => (props.isSelected ? "68px" : "60px")};
+  height: ${(props) => (props.isSelected ? "80px" : "72px")};
   padding-top: 8px;
   padding-bottom: 14px;
   background: white;

--- a/src/components/home/FavoriteFriends.tsx
+++ b/src/components/home/FavoriteFriends.tsx
@@ -1,0 +1,159 @@
+import React, { useCallback, useState } from "react";
+import { View, Text, Image, Pressable, ScrollView, FlatList, ImageProps } from "react-native";
+import styled from "@emotion/native";
+import { Theme } from "@/styles/theme";
+import { FavoriteFriend } from "@/apis/favorite-friends/favorite-friends.type";
+import { getSubjectType } from "@/utils/SubjectUtil";
+
+interface FavoriteFriendsProps {
+  friends: FavoriteFriend[];
+  loading: boolean;
+  error: Error | null;
+  onLoadMore: () => void;
+  hasMore: boolean;
+  totalCount: number;
+  onNavigateToFriendProfile: (userId: number) => void;
+}
+
+const FavoriteFriends: React.FC<FavoriteFriendsProps> = ({
+  friends,
+  loading,
+  error,
+  onLoadMore,
+  hasMore,
+  totalCount,
+  onNavigateToFriendProfile
+}) => {
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const renderFriendItem = useCallback(
+    ({ item, index }: { item: FavoriteFriend; index: number }) => (
+      <FriendItem onPress={() => onNavigateToFriendProfile(item.userId)}>
+        {item.profileImage ? (
+          <AvatarContainer>
+            <Avatar source={{ uri: item.profileImage }} />
+            <SubjectIcon>
+              <Image
+                source={getSubjectType(item.activeClassNow || "기타") as ImageProps}
+                style={{ width: 16, height: 16 }}
+              />
+            </SubjectIcon>
+          </AvatarContainer>
+        ) : (
+          <DefaultAvatar color="#9d9d9d">
+            <DefaultAvatarText>{item.fullName.slice(-2)}</DefaultAvatarText>
+            <SubjectIcon>
+              <Image
+                source={getSubjectType(item.activeClassNow || "기타") as ImageProps}
+                style={{ width: 16, height: 16 }}
+              />
+            </SubjectIcon>
+          </DefaultAvatar>
+        )}
+      </FriendItem>
+    ),
+    [onNavigateToFriendProfile]
+  );
+
+  const handleLoadMore = useCallback(() => {
+    if (!loading && hasMore && !isLoadingMore) {
+      setIsLoadingMore(true);
+      onLoadMore();
+      setIsLoadingMore(false);
+    }
+  }, [loading, hasMore, isLoadingMore, onLoadMore]);
+
+  if (loading && friends.length === 0) return <LoadingText>친구 목록을 불러오는 중...</LoadingText>;
+  if (error) return <ErrorText>친구 목록을 불러오는데 실패했습니다.</ErrorText>;
+  if (friends.length === 0) return <EmptyText>친한 친구를 추가해보세요!</EmptyText>;
+
+  return (
+    <Container>
+      <FlatList
+        data={friends}
+        renderItem={renderFriendItem}
+        keyExtractor={(item) => item.userId.toString()}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        onEndReached={handleLoadMore}
+        onEndReachedThreshold={0.5}
+        ListFooterComponent={() => (isLoadingMore ? <LoadingText>로딩 중...</LoadingText> : null)}
+      />
+    </Container>
+  );
+};
+
+const Container = styled(View)`
+  width: 100%;
+  align-items: flex-start;
+`;
+
+const FriendItem = styled(Pressable)`
+  align-items: center;
+  margin-right: 16px;
+`;
+
+const AvatarContainer = styled(View)`
+  position: relative;
+`;
+
+const Avatar = styled(Image)`
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+`;
+
+const DefaultAvatar = styled(View)<{ color: string }>`
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  border-width: 2px;
+  border-color: ${(props) => props.color};
+  justify-content: center;
+  align-items: center;
+`;
+
+const DefaultAvatarText = styled(Text)`
+  font-size: 16px;
+  font-weight: 500;
+  color: ${Theme.colors.Gray500};
+  font-family: Esamanru OTF;
+  font-style: normal;
+  line-height: var(--Line-Height-Default-Head-Head-01, 20px); /* 125% */
+`;
+
+const SubjectIcon = styled(View)`
+  position: absolute;
+  right: -4px;
+  top: -4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  background-color: white;
+  border-width: 1px;
+  border-color: ${Theme.colors.Gray200};
+  justify-content: center;
+  align-items: center;
+`;
+
+const LoadingText = styled(Text)`
+  font-style: ${Theme.typo.Body_04};
+  color: ${Theme.colors.Gray600};
+`;
+
+const ErrorText = styled(Text)`
+  font-style: ${Theme.typo.Body_04};
+  color: ${Theme.colors.Primary};
+`;
+
+const EmptyText = styled(Text)`
+  font-style: ${Theme.typo.Body_04};
+  color: ${Theme.colors.Gray600};
+`;
+
+const TotalCountText = styled.Text`
+  font-style: ${Theme.typo.Body_04};
+  color: ${Theme.colors.Gray600};
+  margin-bottom: 8px;
+`;
+export default FavoriteFriends;

--- a/src/components/home/MealInfo.tsx
+++ b/src/components/home/MealInfo.tsx
@@ -3,7 +3,6 @@ import { Pressable } from "react-native";
 import { Theme } from "../../styles/theme";
 import styled from "@emotion/native";
 import { MealData } from "@/types/meal";
-import { CustomImage } from "@/pages/home/HomeScreen";
 import { BtnLeft } from "@/assets/assets";
 
 interface MealInfoProps {
@@ -26,47 +25,25 @@ const MealInfo: React.FC<MealInfoProps> = ({ meals, isLoading, error }) => {
     }
   }, []);
 
-  if (isLoading) {
-    return (
-      <LoadingView>
-        <LoadingText>Loading...</LoadingText>
-      </LoadingView>
-    );
-  }
-
-  if (error) {
-    return (
-      <ErrorView>
-        <ErrorText>급식 정보를 불러오는데 실패했습니다.</ErrorText>
-      </ErrorView>
-    );
-  }
-
-  if (!meals || !meals.length) {
-    return (
-      <EmptyView>
-        <EmptyText>오늘은 급식 정보가 없어요.</EmptyText>
-      </EmptyView>
-    );
-  }
+  if (isLoading) return <LoadingText>Loading...</LoadingText>;
+  if (error) return <ErrorText>급식 정보를 불러오는데 실패했습니다.</ErrorText>;
+  if (!meals || !meals.length) return <EmptyText>오늘은 급식 정보가 없어요.</EmptyText>;
 
   const mealTypes: ("조식" | "중식" | "석식")[] = ["조식", "중식", "석식"];
   const currentMeal = meals.find((meal) => meal.type === mealTypes[currentMealIndex]);
 
-  const handlePrevMeal = () => {
-    setCurrentMealIndex((prev) => (prev > 0 ? prev - 1 : mealTypes.length - 1));
-  };
-
-  const handleNextMeal = () => {
-    setCurrentMealIndex((prev) => (prev < mealTypes.length - 1 ? prev + 1 : 0));
+  const handleMealChange = (direction: "prev" | "next") => {
+    setCurrentMealIndex((prev) =>
+      direction === "prev" ? (prev > 0 ? prev - 1 : mealTypes.length - 1) : prev < mealTypes.length - 1 ? prev + 1 : 0
+    );
   };
 
   return (
     <Container>
       <Content>
-        <Pressable onPress={handlePrevMeal}>
+        <ArrowButton onPress={() => handleMealChange("prev")}>
           <CustomImage source={BtnLeft} style={{ transform: [{ scaleX: -1 }, { rotateY: "180deg" }] }} />
-        </Pressable>
+        </ArrowButton>
         <MealContent>
           <MealTitle>{`${new Date().toLocaleDateString("en-US", {
             month: "2-digit",
@@ -74,9 +51,9 @@ const MealInfo: React.FC<MealInfoProps> = ({ meals, isLoading, error }) => {
           })} ${currentMeal?.type || mealTypes[currentMealIndex]}`}</MealTitle>
           <MealMenu>{currentMeal?.menu ? currentMeal.menu.join("\n") : "정보 없음"}</MealMenu>
         </MealContent>
-        <Pressable onPress={handleNextMeal}>
+        <ArrowButton onPress={() => handleMealChange("next")}>
           <CustomImage source={BtnLeft} style={{ transform: [{ scaleX: -1 }] }} />
-        </Pressable>
+        </ArrowButton>
       </Content>
     </Container>
   );
@@ -95,12 +72,7 @@ const Content = styled.View`
   justify-content: space-between;
 `;
 
-const Title = styled.Text`
-  font-style: ${Theme.typo.Body_04_Bold};
-  color: ${Theme.colors.Gray800};
-`;
-
-const ArrowButton = styled.TouchableOpacity`
+const ArrowButton = styled(Pressable)`
   padding: 10px;
 `;
 
@@ -121,27 +93,17 @@ const MealMenu = styled.Text`
   text-align: center;
 `;
 
-const LoadingView = styled.View`
-  padding: 20px;
-  align-items: center;
+const CustomImage = styled.Image`
+  width: 32px;
+  height: 32px;
 `;
 
 const LoadingText = styled.Text`
   color: ${Theme.colors.Gray700};
 `;
 
-const ErrorView = styled.View`
-  padding: 20px;
-  align-items: center;
-`;
-
 const ErrorText = styled.Text`
   color: ${Theme.colors.Primary};
-`;
-
-const EmptyView = styled.View`
-  padding: 20px;
-  align-items: center;
 `;
 
 const EmptyText = styled.Text`

--- a/src/components/home/MealInfo.tsx
+++ b/src/components/home/MealInfo.tsx
@@ -1,0 +1,151 @@
+import React, { useState, useEffect } from "react";
+import { Pressable } from "react-native";
+import { Theme } from "../../styles/theme";
+import styled from "@emotion/native";
+import { MealData } from "@/types/meal";
+import { CustomImage } from "@/pages/home/HomeScreen";
+import { BtnLeft } from "@/assets/assets";
+
+interface MealInfoProps {
+  meals: MealData[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const MealInfo: React.FC<MealInfoProps> = ({ meals, isLoading, error }) => {
+  const [currentMealIndex, setCurrentMealIndex] = useState<number>(0);
+
+  useEffect(() => {
+    const currentHour = new Date().getHours();
+    if (currentHour >= 0 && currentHour < 9) {
+      setCurrentMealIndex(0); // 조식
+    } else if (currentHour >= 9 && currentHour < 14) {
+      setCurrentMealIndex(1); // 중식
+    } else {
+      setCurrentMealIndex(2); // 석식
+    }
+  }, []);
+
+  if (isLoading) {
+    return (
+      <LoadingView>
+        <LoadingText>Loading...</LoadingText>
+      </LoadingView>
+    );
+  }
+
+  if (error) {
+    return (
+      <ErrorView>
+        <ErrorText>급식 정보를 불러오는데 실패했습니다.</ErrorText>
+      </ErrorView>
+    );
+  }
+
+  if (!meals || !meals.length) {
+    return (
+      <EmptyView>
+        <EmptyText>오늘은 급식 정보가 없어요.</EmptyText>
+      </EmptyView>
+    );
+  }
+
+  const mealTypes: ("조식" | "중식" | "석식")[] = ["조식", "중식", "석식"];
+  const currentMeal = meals.find((meal) => meal.type === mealTypes[currentMealIndex]);
+
+  const handlePrevMeal = () => {
+    setCurrentMealIndex((prev) => (prev > 0 ? prev - 1 : mealTypes.length - 1));
+  };
+
+  const handleNextMeal = () => {
+    setCurrentMealIndex((prev) => (prev < mealTypes.length - 1 ? prev + 1 : 0));
+  };
+
+  return (
+    <Container>
+      <Content>
+        <Pressable onPress={handlePrevMeal}>
+          <CustomImage source={BtnLeft} style={{ transform: [{ scaleX: -1 }, { rotateY: "180deg" }] }} />
+        </Pressable>
+        <MealContent>
+          <MealTitle>{`${new Date().toLocaleDateString("en-US", {
+            month: "2-digit",
+            day: "2-digit"
+          })} ${currentMeal?.type || mealTypes[currentMealIndex]}`}</MealTitle>
+          <MealMenu>{currentMeal?.menu ? currentMeal.menu.join("\n") : "정보 없음"}</MealMenu>
+        </MealContent>
+        <Pressable onPress={handleNextMeal}>
+          <CustomImage source={BtnLeft} style={{ transform: [{ scaleX: -1 }] }} />
+        </Pressable>
+      </Content>
+    </Container>
+  );
+};
+
+const Container = styled.View`
+  width: 100%;
+  padding: 20px;
+  background-color: ${Theme.colors.Gray100};
+  border-radius: 10px;
+`;
+
+const Content = styled.View`
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Title = styled.Text`
+  font-style: ${Theme.typo.Body_04_Bold};
+  color: ${Theme.colors.Gray800};
+`;
+
+const ArrowButton = styled.TouchableOpacity`
+  padding: 10px;
+`;
+
+const MealContent = styled.View`
+  flex: 1;
+  align-items: center;
+`;
+
+const MealTitle = styled.Text`
+  font-style: ${Theme.typo.Body_04_Bold};
+  color: ${Theme.colors.Gray800};
+  margin-bottom: 5px;
+`;
+
+const MealMenu = styled.Text`
+  font-style: ${Theme.typo.Body_04};
+  color: ${Theme.colors.Gray700};
+  text-align: center;
+`;
+
+const LoadingView = styled.View`
+  padding: 20px;
+  align-items: center;
+`;
+
+const LoadingText = styled.Text`
+  color: ${Theme.colors.Gray700};
+`;
+
+const ErrorView = styled.View`
+  padding: 20px;
+  align-items: center;
+`;
+
+const ErrorText = styled.Text`
+  color: ${Theme.colors.Primary};
+`;
+
+const EmptyView = styled.View`
+  padding: 20px;
+  align-items: center;
+`;
+
+const EmptyText = styled.Text`
+  color: ${Theme.colors.Gray700};
+`;
+
+export default MealInfo;

--- a/src/components/home/MealInfo.tsx
+++ b/src/components/home/MealInfo.tsx
@@ -4,14 +4,16 @@ import { Theme } from "../../styles/theme";
 import styled from "@emotion/native";
 import { MealData } from "@/types/meal";
 import { BtnLeft } from "@/assets/assets";
+import moment, { Moment } from "moment";
 
 interface MealInfoProps {
   meals: MealData[];
   isLoading: boolean;
   error: Error | null;
+  date: Moment;
 }
 
-const MealInfo: React.FC<MealInfoProps> = ({ meals, isLoading, error }) => {
+const MealInfo: React.FC<MealInfoProps> = ({ meals, isLoading, error, date }) => {
   const [currentMealIndex, setCurrentMealIndex] = useState<number>(0);
 
   useEffect(() => {
@@ -45,7 +47,7 @@ const MealInfo: React.FC<MealInfoProps> = ({ meals, isLoading, error }) => {
           <CustomImage source={BtnLeft} style={{ transform: [{ scaleX: -1 }, { rotateY: "180deg" }] }} />
         </ArrowButton>
         <MealContent>
-          <MealTitle>{`${new Date().toLocaleDateString("en-US", {
+          <MealTitle>{`${moment(date).toDate().toLocaleDateString("en-US", {
             month: "2-digit",
             day: "2-digit"
           })} ${currentMeal?.type || mealTypes[currentMealIndex]}`}</MealTitle>

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -1,0 +1,3 @@
+export const HOME_SCREEN = {
+  FAVORITE_FRIENDS_COUNT: 6
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from "./app";

--- a/src/hooks/useFavoriteFriends.ts
+++ b/src/hooks/useFavoriteFriends.ts
@@ -1,0 +1,57 @@
+import { getFavoriteFriends } from "@/apis/favorite-friends/favorite-friends.apis";
+import { FavoriteFriend } from "@/apis/favorite-friends/favorite-friends.type";
+import { useCallback, useEffect, useState } from "react";
+
+export const useFavoriteFriends = (initialCount: number) => {
+  const [friends, setFriends] = useState<FavoriteFriend[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [totalCount, setTotalCount] = useState(0);
+
+  const fetchFriends = useCallback(
+    async (pageNum: number) => {
+      if (!hasMore && pageNum !== 0) return;
+
+      setLoading(true);
+      try {
+        const { list, total } = await getFavoriteFriends({ count: initialCount, page: pageNum });
+        setTotalCount(total);
+
+        if (pageNum === 0) {
+          setFriends(list);
+        } else {
+          setFriends((prev) => [...prev, ...list]);
+        }
+
+        setHasMore(friends.length + list.length < total);
+      } catch (err: any) {
+        console.error(err.message);
+        console.error(err.stack);
+        setError(err instanceof Error ? err : new Error("An error occurred"));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [initialCount, friends.length]
+  );
+
+  const loadMore = useCallback(() => {
+    if (!loading && hasMore) {
+      fetchFriends(page + 1);
+    }
+  }, [loading, hasMore, page, fetchFriends]);
+
+  useEffect(() => {
+    fetchFriends(0);
+  }, []);
+
+  const refetch = useCallback(() => {
+    setHasMore(true);
+    setPage(0);
+    fetchFriends(0);
+  }, [fetchFriends]);
+
+  return { friends, loading, error, refetch, loadMore, hasMore, totalCount };
+};

--- a/src/hooks/useFavoriteFriends.ts
+++ b/src/hooks/useFavoriteFriends.ts
@@ -17,6 +17,7 @@ export const useFavoriteFriends = (initialCount: number) => {
       setLoading(true);
       try {
         const { list, total } = await getFavoriteFriends({ count: initialCount, page: pageNum });
+
         setTotalCount(total);
 
         if (pageNum === 0) {
@@ -25,7 +26,8 @@ export const useFavoriteFriends = (initialCount: number) => {
           setFriends((prev) => [...prev, ...list]);
         }
 
-        setHasMore(friends.length + list.length < total);
+        setHasMore((prev) => (pageNum === 0 ? list.length < total : prev));
+        setPage((prevPage) => prevPage + 1);
       } catch (err: any) {
         console.error(err.message);
         console.error(err.stack);
@@ -34,18 +36,18 @@ export const useFavoriteFriends = (initialCount: number) => {
         setLoading(false);
       }
     },
-    [initialCount, friends.length]
+    [initialCount]
   );
 
   const loadMore = useCallback(() => {
-    if (!loading && hasMore) {
-      fetchFriends(page + 1);
+    if (!loading && hasMore && friends.length < totalCount) {
+      fetchFriends(page);
     }
-  }, [loading, hasMore, page, fetchFriends]);
+  }, [loading, hasMore, friends.length, totalCount, fetchFriends]);
 
   useEffect(() => {
     fetchFriends(0);
-  }, []);
+  }, [fetchFriends]);
 
   const refetch = useCallback(() => {
     setHasMore(true);

--- a/src/hooks/useMeals.ts
+++ b/src/hooks/useMeals.ts
@@ -1,36 +1,41 @@
-import { useState, useEffect } from "react";
-import { MealData } from "../types/meal";
+import { Moment } from "moment";
 import { fetchMealData } from "@/apis/meal/meal";
+import { MealData } from "@/types/meal";
+import { useCallback, useEffect, useState } from "react";
 
-export const useMeal = (schoolId: number | null, date: string) => {
+export const useMeal = (schoolId: number | null, date: Moment) => {
   const [meals, setMeals] = useState<MealData[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
-    const getMealData = async () => {
-      if (schoolId === null) {
-        setMeals([]);
-        setError(null);
-        return;
-      }
+  const fetchMeals = useCallback(async () => {
+    if (schoolId === null) {
+      setMeals([]);
+      setError(null);
+      return;
+    }
 
-      setIsLoading(true);
-      try {
-        const data = await fetchMealData(schoolId, date);
-        setMeals(data.list);
-        setError(null);
-      } catch (err) {
-        console.log(err);
-        setError(err instanceof Error ? err : new Error("Unknown error occurred"));
-        setMeals([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    getMealData();
+    setIsLoading(true);
+    try {
+      const data = await fetchMealData(schoolId, date.format("YYYY-MM-DD"));
+      setMeals(data.list);
+      setError(null);
+    } catch (err: any) {
+      console.error(err);
+      setError(err instanceof Error ? err : new Error("Unknown error occurred"));
+      setMeals([]);
+    } finally {
+      setIsLoading(false);
+    }
   }, [schoolId, date]);
 
-  return { meals, isLoading, error };
+  useEffect(() => {
+    fetchMeals();
+  }, [fetchMeals]);
+
+  const refetch = useCallback(() => {
+    fetchMeals();
+  }, [fetchMeals]);
+
+  return { meals, isLoading, error, refetch };
 };

--- a/src/hooks/useMeals.ts
+++ b/src/hooks/useMeals.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from "react";
+import { MealData } from "../types/meal";
+import { fetchMealData } from "@/apis/meal/meal";
+
+export const useMeal = (schoolId: number | null, date: string) => {
+  const [meals, setMeals] = useState<MealData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const getMealData = async () => {
+      if (schoolId === null) {
+        setMeals([]);
+        setError(null);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const data = await fetchMealData(schoolId, date);
+        setMeals(data.list);
+        setError(null);
+      } catch (err) {
+        console.log(err);
+        setError(err instanceof Error ? err : new Error("Unknown error occurred"));
+        setMeals([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    getMealData();
+  }, [schoolId, date]);
+
+  return { meals, isLoading, error };
+};

--- a/src/navigations/RootNavigation.ts
+++ b/src/navigations/RootNavigation.ts
@@ -1,0 +1,18 @@
+import { NavigationProp, NavigatorScreenParams } from "@react-navigation/native";
+import { HomeStackParamList } from "./HomeStackNavigation";
+import { FriendsStackParamList } from "./FriendsStackNavigation";
+import { CalendarStackParamList } from "./CalendarStackNavigation";
+import { MemoStackParamList } from "./MemoStackNavigation";
+import { SettingStackParamList } from "./SettingStackNavigation";
+import { SignUpStackParamList } from "./SignUpStackNavigation";
+
+export type RootStackParamList = {
+  Home: NavigatorScreenParams<HomeStackParamList>;
+  Friends: NavigatorScreenParams<FriendsStackParamList>;
+  Calendar: NavigatorScreenParams<CalendarStackParamList>;
+  Memo: NavigatorScreenParams<MemoStackParamList>;
+  Setting: NavigatorScreenParams<SettingStackParamList>;
+  SignUp: NavigatorScreenParams<SignUpStackParamList>;
+};
+
+export type RootNavigationProp = NavigationProp<RootStackParamList>;

--- a/src/pages/friends/FriendsList.tsx
+++ b/src/pages/friends/FriendsList.tsx
@@ -34,26 +34,6 @@ export default function FriendsList() {
   const { token } = useAuthStore();
   const [enteredText, setEnteredText] = useState("");
 
-  const fetchFavoriteFriends = async () => {
-    setLoading(true);
-    try {
-      const response = await axios.get("https://b-site.site/friends/favorites", {
-        params: {
-          page: 0,
-          count: 100
-        },
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-
-      setFavoriteFriends({ list: response.data.list });
-    } catch (error) {
-      console.error("Error fetching schoolmates:", error);
-    } finally {
-      setLoading(false); // 로딩 끝
-    }
-  };
   const fetchFriends = async (page: number) => {
     setLoading(true); // 로딩 시작
     try {
@@ -68,8 +48,12 @@ export default function FriendsList() {
       });
 
       const newFriends = response.data.all;
+      const favoriteFriends = response.data.favaorites;
       setFriends((prev) => ({
         list: page === 0 ? newFriends : [...prev.list, ...newFriends]
+      }));
+      setFavoriteFriends((prev) => ({
+        list: page === 0 ? favoriteFriends : [...prev.list, ...favoriteFriends]
       }));
     } catch (error) {
       console.error("Error fetching friends:", error);
@@ -110,7 +94,6 @@ export default function FriendsList() {
   };
 
   useEffect(() => {
-    fetchFavoriteFriends();
     fetchFriends(0);
     // console.log("friendslist.tsx");
   }, []);

--- a/src/pages/home/HomeScreen.tsx
+++ b/src/pages/home/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { SafeAreaView, Pressable, ScrollView, View, Text, Image } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import styled from "@emotion/native";
 import { useMeal } from "@/hooks/useMeals";
 import MealInfo from "@/components/home/MealInfo";
@@ -27,13 +27,6 @@ const HomeScreen: React.FC = () => {
 
   const navigateToFriendsList = () => {
     navigation.navigate("Friends", { screen: "FriendListScreen" });
-  };
-
-  const navigateToFriendProfile = (userId: number) => {
-    navigation.navigate("Friends", {
-      screen: "FriendProfile",
-      params: { userId }
-    });
   };
 
   const {
@@ -67,10 +60,12 @@ const HomeScreen: React.FC = () => {
     }
   }, []);
 
-  useEffect(() => {
-    getUserProfile();
-    refetchFriends();
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      getUserProfile();
+      refetchFriends(); // 화면에 돌아올 때마다 친구 목록을 다시 불러옴
+    }, [getUserProfile, refetchFriends])
+  );
 
   useEffect(() => {
     refetchMeals();
@@ -109,7 +104,6 @@ const HomeScreen: React.FC = () => {
               error={friendsError}
               onLoadMore={loadMoreFriends}
               hasMore={hasMoreFriends}
-              onNavigateToFriendProfile={navigateToFriendProfile}
               totalCount={totalFavoriteFriends}
             />
           </Section>

--- a/src/pages/home/HomeScreen.tsx
+++ b/src/pages/home/HomeScreen.tsx
@@ -1,12 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { SafeAreaView, Pressable, ScrollView } from "react-native";
-import { NavigationProp, useNavigation, useFocusEffect } from "@react-navigation/native";
+import React, { useCallback, useEffect, useState } from "react";
+import { SafeAreaView, Pressable, ScrollView, View, Text, Image } from "react-native";
+import { useNavigation } from "@react-navigation/native";
 import styled from "@emotion/native";
 import { useMeal } from "@/hooks/useMeals";
 import MealInfo from "@/components/home/MealInfo";
 import { BtnLeft, ChevronRight } from "@/assets/assets";
 import DateCarousel from "@/components/home/DateCarousel";
-import { HomeStackParamList } from "@/navigations/HomeStackNavigation";
 import { Theme } from "@/styles/theme";
 import { customAxios } from "@/apis/instance";
 import { User } from "../memo/ChatScreen";
@@ -14,11 +13,17 @@ import { useFavoriteFriends } from "@/hooks/useFavoriteFriends";
 import FavoriteFriends from "@/components/home/FavoriteFriends";
 import { HOME_SCREEN } from "@/constants";
 import { RootNavigationProp } from "@/navigations/RootNavigation";
+import moment from "moment";
 
 const HomeScreen: React.FC = () => {
   const navigation = useNavigation<RootNavigationProp>();
   const [loading, setLoading] = useState(false);
   const [userInfo, setUserInfo] = useState<User | null>(null);
+  const [selectedDate, setSelectedDate] = useState(moment());
+
+  const handleDateChange = (date: moment.Moment) => {
+    setSelectedDate(date);
+  };
 
   const navigateToFriendsList = () => {
     navigation.navigate("Friends", { screen: "FriendListScreen" });
@@ -36,7 +41,7 @@ const HomeScreen: React.FC = () => {
     isLoading: mealsLoading,
     error: mealsError,
     refetch: refetchMeals
-  } = useMeal(userInfo?.schoolId || null, new Date().toISOString().split("T")[0]);
+  } = useMeal(userInfo?.schoolId || null, selectedDate);
 
   const {
     friends,
@@ -62,19 +67,19 @@ const HomeScreen: React.FC = () => {
     }
   }, []);
 
-  useEffect(
-    () => {
-      getUserProfile();
-      refetchMeals();
-      refetchFriends();
-    },
-    [] //   [friends]
-  );
+  useEffect(() => {
+    getUserProfile();
+    refetchFriends();
+  }, []);
+
+  useEffect(() => {
+    refetchMeals();
+  }, [selectedDate]);
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: "#fff" }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: "#FEFEFA" }}>
       <Container>
-        <DateCarousel />
+        <DateCarousel selectedDate={selectedDate} onDateChange={handleDateChange} />
         <ScrollView>
           <Section>
             <SectionHeader>
@@ -115,7 +120,7 @@ const HomeScreen: React.FC = () => {
             {loading ? (
               <EmptyMealLabel>사용자 정보를 불러오는 중...</EmptyMealLabel>
             ) : userInfo?.schoolId ? (
-              <MealInfo meals={meals} isLoading={mealsLoading} error={mealsError} />
+              <MealInfo meals={meals} isLoading={mealsLoading} error={mealsError} date={selectedDate} />
             ) : (
               <EmptyMealLabel>학교 정보가 없습니다.</EmptyMealLabel>
             )}
@@ -134,8 +139,8 @@ const Container = styled.View`
 
 const Section = styled.View`
   width: 100%;
-  gap: 10px;
-  padding: 0 20px;
+  gap: 12px;
+  padding: 0 16px;
   align-items: center;
 `;
 
@@ -148,18 +153,16 @@ const SectionHeader = styled.View`
 `;
 
 const SectionHeaderTitle = styled.Text`
-  color:  ${Theme.colors.Gray900};
-  font-family: Pretendard;
+  color: #262626;
+  font-family: "Pretendard";
   font-size: 18px;
-  font-style: normal;
   font-weight: 500;
-  line-height: normal;
-  letter-spacing: 0.25px;
+  line-height: 26px;
 `;
 
 const EmptyTimeTableBox = styled.View`
   width: 100%;
-  height: 270px;
+  height: 267px;
   background-color: #f3f2ff;
   border-radius: 20px;
   justify-content: center;
@@ -168,32 +171,41 @@ const EmptyTimeTableBox = styled.View`
 `;
 
 const EmptyTimeTableBoxLabel = styled.Text`
-  font-style: ${Theme.typo.Body_04_Bold};
+  color: #555555;
+  font-family: "Pretendard";
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 28px;
 `;
 
 const AddTimeTableButton = styled(Pressable)`
-  width: 170px;
-  height: 56px;
+  padding: 16px 14px 16px 12px;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  background-color: ${Theme.colors.Violet};
-  border-radius: 100px;
+  background-color: #8a7eff;
+  border-radius: 56px;
 `;
 
 const AddTimeTableButtonText = styled.Text`
-  font-style: ${Theme.typo.Body_04_Bold};
-  color: #fff;
+  color: white;
+  font-family: "Pretendard";
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 20px;
+  margin-right: 6px;
 `;
 
 const CustomImage = styled.Image`
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
 `;
 
 const EmptyMealLabel = styled.Text`
-  font-style: ${Theme.typo.Body_04};
-  color: ${Theme.colors.Gray600};
+  font-family: "Pretendard";
+  font-size: 16px;
+  font-weight: 500;
+  color: #7b7b7b;
   padding: 20px 0;
 `;
 

--- a/src/pages/home/HomeScreen.tsx
+++ b/src/pages/home/HomeScreen.tsx
@@ -4,9 +4,14 @@ import { HomeStackParamList } from "../../navigations/HomeStackNavigation";
 import { Theme } from "../../styles/theme";
 import styled from "@emotion/native";
 import DateCarousel from "../../components/home/DateCarousel";
+import useUserStore from "@/store/UserStore";
+import { useMeal } from "@/hooks/useMeals";
+import MealInfo from "@/components/home/MealInfo";
 
 function HomeScreen() {
   const navigation = useNavigation<NavigationProp<HomeStackParamList>>();
+  const { schoolId } = useUserStore();
+  const { meals, isLoading, error } = useMeal(schoolId, new Date().toISOString().split("T")[0]);
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: "#fff" }}>
@@ -32,7 +37,6 @@ function HomeScreen() {
             </AddTimeTableButton>
           </EmptyTimeTableBox>
         </Section>
-
         <Section>
           <SectionHeader>
             <SectionHeaderTitle>친한 친구들</SectionHeaderTitle>
@@ -68,24 +72,27 @@ function HomeScreen() {
           </FriendList>
           {/* <EmptyFriendsLabel>친한 친구들을 추가해보세요!</EmptyFriendsLabel> */}
         </Section>
-
-        <Section>
-          <SectionHeader>
-            <SectionHeaderTitle>오늘의 급식</SectionHeaderTitle>
-            <Pressable>
-              <CustomImage
-                source={require("../../assets/images/btn_left.png")}
-                style={{ transform: [{ scaleX: -1 }] }}
-              />
-            </Pressable>
-          </SectionHeader>
-        </Section>
+        {schoolId !== null ? (
+          <Section>
+            <SectionHeader>
+              <SectionHeaderTitle>오늘의 급식</SectionHeaderTitle>
+            </SectionHeader>
+            <MealInfo meals={meals} isLoading={isLoading} error={error} />
+          </Section>
+        ) : (
+          <Section>
+            <SectionHeader>
+              <SectionHeaderTitle>오늘의 급식</SectionHeaderTitle>
+            </SectionHeader>
+            <EmptyMealLabel>학교 정보가 없습니다.</EmptyMealLabel>
+          </Section>
+        )}
       </Container>
     </SafeAreaView>
   );
 }
 
-const Container = styled(View)`
+export const Container = styled(View)`
   flex: 1;
   align-items: center;
   gap: 20px;
@@ -98,14 +105,14 @@ const Section = styled(View)`
   align-items: center;
 `;
 
-const SectionHeader = styled(View)`
+export const SectionHeader = styled(View)`
   width: 100%;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
 `;
 
-const SectionHeaderTitle = styled(Text)`
+export const SectionHeaderTitle = styled(Text)`
   font-style: ${Theme.typo.Body_04};
 `;
 
@@ -144,7 +151,7 @@ const EmptyFriendsLabel = styled(Text)`
   padding: 20px 0;
 `;
 
-const CustomImage = styled(Image)`
+export const CustomImage = styled(Image)`
   width: 32px;
   height: 32px;
 `;
@@ -168,6 +175,12 @@ const Avatar = styled.View`
 const AvatarText = styled.Text`
   font-style: ${Theme.typo.Body_04_Bold};
   color: ${Theme.colors.Gray700};
+`;
+
+const EmptyMealLabel = styled(Text)`
+  font-style: ${Theme.typo.Body_04};
+  color: ${Theme.colors.Gray600};
+  padding: 20px 0;
 `;
 
 export default HomeScreen;

--- a/src/pages/setting/SettingHomeScreen.tsx
+++ b/src/pages/setting/SettingHomeScreen.tsx
@@ -16,7 +16,7 @@ type User = {
   id: number;
   status: string;
   provider: string;
-  schooId: number;
+  schoolId: number;
   schoolName: string;
   grade: number;
   className: string;
@@ -141,7 +141,7 @@ function SettingHomeScreen({ navigation, route }: SettingHomeScreenProps) {
             navigation.navigate("ProfileScreen", {
               fullName: userInfo?.fullName,
               schoolName: userInfo?.schoolName,
-              schoolId: userInfo?.schooId,
+              schoolId: userInfo?.schoolId,
               grade: userInfo?.grade,
               className: userInfo?.className,
               isTimetablePublic: userInfo?.isTimetablePublic,

--- a/src/types/meal.ts
+++ b/src/types/meal.ts
@@ -1,0 +1,10 @@
+export interface MealData {
+  date: string;
+  type: "조식" | "중식" | "석식";
+  menu: string[];
+}
+
+export interface MealResponse {
+  total: number;
+  list: MealData[];
+}


### PR DESCRIPTION
## 급식
https://github.com/user-attachments/assets/08b2232f-5aa8-44d3-ab9e-13f77fcd18b9
- 0시~09시: 조식 우선 표시
- 09~14: 중식 우선 표시
- 14~23: 석식 우선 표시 

- 선택된 날짜 변경되면 해당 날짜 급식 API 호출





## 즐겨찾기 친구
https://github.com/user-attachments/assets/4fe3aca8-c860-4b75-a174-e2f9a3074f21
- 6개 표시, 스크롤 끝에서 다음 페이지 호출


## DateCarousel
- 오늘은 점 세 개
- 나머지는 회색 점 하나
- 선택된 날짜는 밑에 검정색 줄, 검정색 테두리, 크기 커짐

https://github.com/user-attachments/assets/752c8ee1-304d-4780-92ef-8651bc1eaf00



### 그 외 전달사항
- 즐겨찾기 친구에서  > 버튼은 친구목록으로 이동하는데
- 그 프로필 클릭시 프로필 화면으로 이동이 안되는데 해결을 못했습니다 😓

- [feat: 친구목록 즐겨찾기 API 응답에서 사용(검색어 반영한 데이터)](https://github.com/project-baam/frontend/commit/6361e5c81b32206b34392d1260541e388361d4dc)
: 해당 커밋은 친구 목록의 즐겨찾기는 `/freidns` API 응답에서 favorite 도 같이 보내서 그거 사용하도록 수정했는데, 확인부탁드립니다ㅎㅎ 
`/friends/favorites GET` 이 API 는 검색기능 없이 홈에서만 사용하는 용도여서요! 


- 월 옆에 
<img width="37" alt="image" src="https://github.com/user-attachments/assets/50a08a42-aa6a-4e76-96ac-77755daddc87">


이 버튼 기획이 없어서 날짜만 전달해서 API 호출하려고 해봤는데 

<img src="https://github.com/user-attachments/assets/968a9b68-e11f-4164-9456-fdcf00718978" width="300" alt="Screenshot">



- 연도도 선택이 되어야할 것 같은데 

<img src="https://github.com/user-attachments/assets/e6bc75b9-8814-43ca-9a29-63f9a7643af2" width="300" alt="Screenshot">

- UI 에 연도는 없어서.. 애매해서 그냥 버튼 이벤트 생략했습니다ㅠ 